### PR TITLE
chore: add Phase 1 Go/No-Go issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/phase-checklist.md
+++ b/.github/ISSUE_TEMPLATE/phase-checklist.md
@@ -1,0 +1,46 @@
+---
+name: "Phase 1: Go/No-Go Checklist"
+about: "Standardized acceptance checklist aligned with Phase 1 gating"
+title: "Phase 1 — [Area]: Go/No-Go Checklist"
+labels: ["phase:1", "checklist", "go-no-go"]
+assignees: []
+---
+
+# Phase 1 — Go/No-Go Checklist
+
+> Use this template to validate scope, plan, and quality gates before implementation. Replace bracketed text and tick checkboxes as you complete each item.
+
+## Context
+- [ ] Problem statement:
+- [ ] Success criteria (measurable):
+- [ ] DRI/Owner: @
+- [ ] Stakeholders: @ @
+- [ ] In-scope:
+- [ ] Out-of-scope:
+
+## Technical Plan
+- [ ] Approach/design summary:
+- [ ] Tasks breakdown with rough estimates:
+- [ ] Dependencies (owner, ETA):
+
+## Quality & Risk
+- [ ] Acceptance criteria (Given/When/Then):
+- [ ] Test plan (critical paths + edge cases):
+- [ ] Observability (logs/metrics/alerts):
+- [ ] Security & privacy (tokens/PII/data):
+- [ ] Performance/budget considerations:
+
+## Delivery
+- [ ] Rollout plan:
+- [ ] Rollback strategy:
+- [ ] Documentation (README/ADR/CHANGELOG):
+- [ ] Risks + mitigations:
+- [ ] Go/No-Go gate owner:
+- [ ] Go/No-Go review date:
+
+## Decision
+- [ ] Go
+- [ ] No-Go
+
+## Notes
+- Additional context and links:


### PR DESCRIPTION
## Summary
- Add standardized Phase 1 Go/No-Go issue template
- Append checklist to issues #2–#6 for cross-topic alignment

## Context
This template aligns Phase 1 gating across topics, ensuring clear scope, quality gates, and a documented Go/No-Go decision.

## Test plan
- Create a test issue using the new template and fill the checkboxes
- Verify checkboxes render and labels are applied