### PR TITLE
feat(ops): add release readiness issue forms and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/go-no-go.yml
+++ b/.github/ISSUE_TEMPLATE/go-no-go.yml
@@ -1,0 +1,69 @@
+name: "Go / No-Go Meeting"
+description: "Formal go/no-go checkpoint for release"
+labels: ["release", "go-no-go"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Go / No-Go
+        Use this form to record the outcome of the go/no-go review.
+  - type: input
+    id: version
+    attributes:
+      label: Release version
+      placeholder: vX.Y.Z
+    validations:
+      required: true
+  - type: input
+    id: date
+    attributes:
+      label: Meeting date/time
+      placeholder: 2026-02-23 10:00 local
+    validations:
+      required: true
+  - type: textarea
+    id: attendees
+    attributes:
+      label: Attendees
+      placeholder: |
+        - @owner (Release Manager)
+        - @qa
+        - @eng-lead
+        - @ops
+        - @product
+    validations:
+      required: true
+  - type: checkboxes
+    id: criteria
+    attributes:
+      label: Criteria review
+      options:
+        - label: Release Readiness issue approved
+        - label: All critical bugs closed or accepted with mitigation
+        - label: Rollout/rollback plan reviewed
+        - label: Monitoring and on-call ready
+    validations:
+      required: true
+  - type: dropdown
+    id: decision
+    attributes:
+      label: Decision
+      options:
+        - GO
+        - NO-GO
+        - GO WITH CONDITIONS
+    validations:
+      required: true
+  - type: textarea
+    id: conditions
+    attributes:
+      label: Conditions or blockers (if any)
+      placeholder: List actions required before GO, or reasons for NO-GO
+  - type: input
+    id: approver
+    attributes:
+      label: Approver
+      placeholder: @owner
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/post-release-review.yml
+++ b/.github/ISSUE_TEMPLATE/post-release-review.yml
@@ -1,0 +1,54 @@
+name: "Post-Release Review"
+description: "Collect outcomes and learnings after release"
+labels: ["release", "post-release"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Post-Release Review
+        Summarize what happened during and after the release. Capture metrics and learnings.
+  - type: input
+    id: version
+    attributes:
+      label: Release version
+      placeholder: vX.Y.Z
+    validations:
+      required: true
+  - type: input
+    id: window
+    attributes:
+      label: Observation window
+      placeholder: e.g., First 72 hours post-deploy
+    validations:
+      required: true
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Outcome metrics
+      description: SLOs, error rates, performance, adoption, support tickets, incidents
+      placeholder: |
+        - API error rate: ...
+        - Latency P95: ...
+        - Support tickets: ...
+        - Incidents: ...
+    validations:
+      required: true
+  - type: textarea
+    id: incidents
+    attributes:
+      label: Incidents & mitigations
+      placeholder: |
+        - Incident #123: root cause, timeline, fix, follow-ups
+  - type: textarea
+    id: learnings
+    attributes:
+      label: Learnings & improvements
+      placeholder: What went well? What to improve in process/tooling?
+  - type: input
+    id: approver
+    attributes:
+      label: Approver
+      placeholder: @owner
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/release-readiness.yml
+++ b/.github/ISSUE_TEMPLATE/release-readiness.yml
@@ -1,0 +1,75 @@
+name: "Release Readiness Checklist"
+description: "Pre-release readiness gate: verify scope, testing, docs, ops, comms"
+labels: ["release", "readiness"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Release Readiness
+        Use this form to validate that the release candidate is ready to ship. Link evidence in each section.
+  - type: input
+    id: version
+    attributes:
+      label: Release version (semver)
+      description: e.g. v0.2.0
+      placeholder: vX.Y.Z
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope & Changes
+      description: Summarize the changes included in this release. Link milestone, changelog, or PR list.
+      placeholder: |
+        - Milestone: ...
+        - Changelog PR: ...
+        - Notable changes: ...
+    validations:
+      required: true
+  - type: checkboxes
+    id: qa
+    attributes:
+      label: QA & Testing
+      options:
+        - label: All unit tests passing in CI
+        - label: Manual smoke test of critical paths completed
+        - label: Backwards compatibility confirmed or breaking changes documented
+        - label: Security scan shows no new high/critical issues
+    validations:
+      required: true
+  - type: textarea
+    id: docs
+    attributes:
+      label: Docs & Communications
+      description: Link to docs/release-readiness.md with filled evidence and any public comms draft
+      placeholder: |
+        - Release notes draft: link
+        - Migration guide (if applicable): link
+        - docs/release-readiness.md: link
+    validations:
+      required: true
+  - type: checkboxes
+    id: ops
+    attributes:
+      label: Operations
+      options:
+        - label: Rollout plan documented (how to deploy, canary steps)
+        - label: Rollback plan documented (how to revert)
+        - label: Monitoring/alerts updated for new/changed components
+        - label: Incident playbook updated (if impacted)
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks & Mitigations
+      description: Enumerate top risks and how we mitigate/monitor them
+  - type: input
+    id: approver
+    attributes:
+      label: Approver (Go/No-Go owner)
+      description: GitHub handle of approver responsible for final decision
+      placeholder: @owner
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ docker compose -f deploy/docker-compose.yml up -d
 
 ---
 
+## Release Process
+
+See the Release Readiness evidence template: [docs/release-readiness.md](docs/release-readiness.md)
+
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -1,0 +1,47 @@
+# Release Readiness Evidence
+
+Provide links and evidence for the upcoming release. Copy this file for each release (e.g., docs/releases/v0.2.0/readiness.md) and link it from the Release Readiness issue.
+
+## Release Metadata
+- Version: vX.Y.Z
+- Target date: YYYY-MM-DD
+- Release Manager: @handle
+- Milestone: <link>
+
+## Scope & Changes
+- Changelog PR: <link>
+- Milestone/Issues: <link>
+- Notable changes:
+  - ...
+
+## QA & Testing
+- CI status: <link to workflow run>
+- Test coverage report: <link>
+- Manual test notes: <doc link>
+- Backwards compatibility notes: <doc link>
+
+## Security
+- Security scan report: <link>
+- Dependency audit: <link>
+- Threat assessment changes: <notes>
+
+## Operations
+- Rollout plan: <doc link>
+- Rollback plan: <doc link>
+- Monitoring dashboards: <links>
+- Alerting updates: <links>
+
+## Communications
+- Release notes draft: <doc link>
+- Docs updates PRs: <links>
+- Migration guide (if applicable): <link>
+
+## Risks & Mitigations
+- Top risks:
+  - ...
+- Mitigations:
+  - ...
+
+## Decision Log
+- Go/No-Go decision issue: <link>
+- Approver: @handle


### PR DESCRIPTION
## Summary
- Add three GitHub Issue Forms: release-readiness, go-no-go, post-release-review
- Add docs/release-readiness.md with evidence placeholders
- Update README to link to release readiness documentation

## Test plan
- Verify new issue templates appear under New Issue → 'Release Readiness Checklist', 'Go / No-Go Meeting', 'Post-Release Review'
- Open each form to ensure fields render and required validations work
- Confirm docs/release-readiness.md is accessible and linked from README

🤖 Generated with Claude Code