### PR TITLE
chore(ci): add Codecov integration, coverage badge, and thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
-        if: github.event_name == 'push'
         with:
           files: coverage/lcov.info
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/ds0857/x-skynet/releases/tag/v0.1.0)
 [![CI](https://github.com/ds0857/x-skynet/actions/workflows/ci.yml/badge.svg)](https://github.com/ds0857/x-skynet/actions/workflows/ci.yml)
 [![Security](https://github.com/ds0857/x-skynet/actions/workflows/security.yml/badge.svg)](https://github.com/ds0857/x-skynet/actions/workflows/security.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/ds0857/x-skynet?logo=codecov&label=coverage)](https://codecov.io/gh/ds0857/x-skynet)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6)](https://www.typescriptlang.org/)
 [![pnpm](https://img.shields.io/badge/pnpm-monorepo-orange)](https://pnpm.io/)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,35 @@
+codecov:
+  require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: 70..100
+  status:
+    project:
+      default:
+        # Keep overall coverage from dropping more than 2%
+        target: auto
+        threshold: 2%
+        if_not_found: success
+    patch:
+      default:
+        # Encourage good coverage on new/changed code
+        target: 80%
+        threshold: 1%
+
+# These are mostly excluded from Jest coverage collection already, but we also
+# ignore them here so Codecov matches local coverage and avoids noise
+ignore:
+  - "packages/**/src/**/*.d.ts"
+  - "packages/**/src/__tests__/**"
+  - "packages/dag-viewer/**"
+  - "packages/logger/**"
+  - "packages/plugin-claude/**"
+  - "packages/plugin-http/**"
+  - "packages/plugin-telegram/**"
+  - "packages/sdk-js/**"
+  - "packages/cli/**"
+
+# Reduce noise on PRs — rely on checks UI instead
+comment: false


### PR DESCRIPTION
This PR wires up Codecov and coverage thresholds.

- Add codecov.yml with project/patch status targets
- Ensure CI always uploads lcov via codecov-action v4
- Add README badge for coverage

CI runs tests with coverage (lcov, html). Codecov is configured to allow small fluctuations and encourage patch coverage.

Notes:
- codecov upload runs on PRs and pushes
- artifact coverage report retained for 7 days

