### PR TITLE
ci(codecov): enforce project+patch gates and add docs

### DIFF
--- a/.changeset/cli-agents-logging-preview.md
+++ b/.changeset/cli-agents-logging-preview.md
@@ -1,0 +1,12 @@
+---
+"@xskynet/cli": minor
+"@xskynet/core": patch
+"@xskynet/sdk-js": patch
+"@xskynet/contracts": patch
+---
+
+docs(cli): add preview docs for `xskynet agents` subcommands and logging model.
+
+- Introduces docs/cli-agents.md and docs/logging.md
+- Establishes flags for log level/format/file and run correlation fields
+- No runtime changes yet; implementation to follow in P2-06c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs on the same ref
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for Codecov OIDC
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+
+      - name: Install pnpm and dependencies
+        run: |
+          npm i -g pnpm@9
+          # Use non-frozen lockfile for now since lockfile may not be committed
+          pnpm install --frozen-lockfile=false
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test (with coverage)
+        run: pnpm test
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.node-version }}
+          path: coverage
+          if-no-files-found: warn
+
+      - name: Upload coverage to Codecov via OIDC
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          use_oidc: true
+          files: coverage/lcov.info
+          flags: node-${{ matrix.node-version }}
+          fail_ci_if_error: false

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Run commitlint when available; skip (no-fail) otherwise
+if command -v pnpm >/dev/null 2>&1 && pnpm exec commitlint --version >/dev/null 2>&1; then
+  pnpm exec commitlint --edit "$1"
+else
+  echo "Skipping commitlint: pnpm/commitlint not available"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Run lint-staged when available; skip (no-fail) otherwise
+if command -v pnpm >/dev/null 2>&1 && pnpm exec lint-staged --version >/dev/null 2>&1; then
+  pnpm exec lint-staged
+else
+  echo "Skipping lint-staged: pnpm/lint-staged not available"
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to X‑Skynet
+
+Thanks for your interest in contributing! This document explains our PR labeling automation and how to work with it.
+
+## Pull Request automation
+
+We use GitHub Actions to automatically label PRs by both code area and size. Labels help reviewers route, prioritize, and understand change impact quickly.
+
+### 1) Path‑based auto‑labels (scope:\*)
+
+Workflow: `.github/workflows/labeler.yml` (actions/labeler@v5)
+
+- Trigger: `pull_request_target` on opened/synchronize/reopened
+- Permissions: `contents: read`, `pull-requests: write`
+- Config: `.github/labeler.yml`
+- Behavior: Adds `scope:*` labels based on changed files
+
+Common mappings (see full list in `.github/labeler.yml`):
+
+- `scope:contracts` → `packages/contracts/**`
+- `scope:core` → `src/core/**`
+- `scope:agents` → `src/agents/**`
+- `scope:skills` → `src/skills/**`
+- `scope:channels` → `src/channels/**`
+- `scope:apps` → `apps/**`
+- `scope:docs` → `docs/**`, `README.md`
+- `scope:tests` → `tests/**`
+- `scope:ci` → `.github/workflows/**`
+- `scope:repo` → repo configs (eslint/prettier/tsconfig/etc.)
+
+To add or change mappings, edit `.github/labeler.yml` (v5 syntax) and open a PR.
+
+### 2) Size auto‑labels (size:\*)
+
+Workflow: `.github/workflows/size-label.yml` (pascalgn/size-label-action@v0.5.5)
+
+- Trigger: `pull_request_target` on opened/synchronize/reopened
+- Permissions: `contents: read`, `pull-requests: write`
+- Thresholds:
+  - `size:XS` — up to 10 changed lines
+  - `size:S` — 11–50
+  - `size:M` — 51–200
+  - `size:L` — 201–500
+  - `size:XL` — 501+
+- Notes:
+  - We exclude some non-code churn from the size calculation (e.g., lockfiles, docs). Adjust the `IGNORED` env in the workflow if needed.
+  - Labels are named `size:*` to align with our catalog.
+
+### 3) Label catalog and sync
+
+Manifest: `.github/labels.yml`
+
+Workflow: `.github/workflows/sync-labels.yml` (micnncim/action-label-syncer@v1)
+
+- When labels.yml changes on `main`, or when triggered manually, the workflow will create/update labels.
+- Set `prune: true` to remove labels not in the manifest (current setting).
+- You can also run the workflow via the "Actions" tab → "Sync repository labels" → "Run workflow".
+
+Label families we use:
+
+- `type:*` — feature, bug, docs, chore, test, refactor, ci
+- `scope:*` — areas of the codebase (see above)
+- `semver:*` — major, minor, patch
+- `status:*` — ready, in-progress, blocked, needs-info
+- `priority:*` — P0/P1/P2/P3
+- `size:*` — XS/S/M/L/XL (applied automatically)
+
+### Security notes
+
+- Both workflows use `pull_request_target` and do not check out the PR head. They operate with the base repository context and least-privilege token scopes.
+- Path labeler reads config from the default branch; contributors cannot change label mappings from a forked PR.
+
+### Proposing label changes
+
+1. Update `.github/labels.yml` (add/edit label entries).
+2. If needed, update `.github/labeler.yml` to map paths to new `scope:*` labels.
+3. Open a PR. After merge, labels will be synced automatically on `main` (or a maintainer can run the sync workflow manually).
+
+## Test coverage and Codecov
+
+We require tests with coverage and enforce Codecov gates on pull requests:
+
+- Project coverage gate: target: auto with a 2% threshold. Prevents overall coverage from regressing significantly.
+- Patch coverage gate: target: 80% with a 1% threshold, only on pull requests. Ensures changed lines are reasonably tested.
+- Per-package coverage via Codecov Components: Each package under packages/\* is tracked as its own component. Codecov creates status checks per component (e.g., codecov/components/pkg-core/project and codecov/components/pkg-core/patch) in addition to the global codecov/project and codecov/patch checks. These appear automatically once Codecov processes a commit with the component definitions from codecov.yml.
+
+Local workflow:
+
+- Run tests with coverage: pnpm test (Vitest v8). This generates coverage/lcov.info.
+- Aim to keep patch coverage ≥ 80% on your changes; add tests for new logic.
+- If some lines are intentionally hard to test, consider refactoring to isolate them or use /_ istanbul ignore next _/ sparingly.
+
+CI notes:
+
+- CI uploads coverage to Codecov via OIDC (codecov/codecov-action@v4). We tag uploads with a node-20.x flag for matrix stability. Components are derived from file paths and do not require separate uploads.
+- Required checks typically include: build-test, codecov/patch, codecov/project, and where present, component checks like codecov/components/pkg-\*/{project,patch}.
+
+### Questions
+
+Open an issue with the `type:docs` label or ask in the discussion forum if you need help with the automation.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Open-source AI agent orchestration framework — 15 minutes to your first runnin
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/ts-TypeScript-3178c6)](https://www.typescriptlang.org/)
+[![codecov](https://codecov.io/gh/ds0857/x-skynet/branch/main/graph/badge.svg)](https://codecov.io/gh/ds0857/x-skynet)
 
 ## Why X-Skynet
 
@@ -13,8 +14,31 @@ Open-source AI agent orchestration framework — 15 minutes to your first runnin
 
 ## Quick Start
 
-> Coming soon. The goal is: `pnpm create xskynet` → 15 minutes to a running agent.
+See docs/Quickstart.md.
+
+## Monorepo structure
+
+- apps/
+  - demo/ — minimal demo using @xskynet/core
+- packages/
+  - contracts/ — core domain contracts
+  - core/ — engine/core helpers (currently minimal)
+  - cli/ — CLI skeleton
+  - plugin-claude/, plugin-http/, plugin-shell/ — plugin packages (skeletons)
+  - tsconfig/ — shared tsconfig presets
+  - eslint-config/ — shared ESLint config
+  - prettier-config/ — shared Prettier config
+  - viewer/ — DAG run viewer (vite)
+- docs/
+- examples/
+
+## Scripts
+
+- pnpm dev — build core then run demo
+- pnpm lint — lint repository
+- pnpm typecheck — project-wide typecheck
+- pnpm test — run unit tests with coverage
 
 ## Contributing
 
-Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines (to be added).
+Please see CONTRIBUTING.md (to be added).

--- a/codecov.yml
+++ b/codecov.yml
@@ -38,3 +38,59 @@ flag_management:
   individual_flags:
     - name: "node-20.x"
       carryforward: true
+
+# Define per-package Components so each package has its own coverage status checks
+# See: https://docs.codecov.com/docs/components
+component_management:
+  # Default status rules applied to all components (can be overridden per-component)
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 2%
+      - type: patch
+        target: 80%
+        threshold: 1%
+        only_pulls: true
+  # Individual package components (monorepo)
+  individual_components:
+    - component_id: pkg-cli
+      name: "pkg:cli"
+      paths:
+        - "packages/cli/**"
+    - component_id: pkg-contracts
+      name: "pkg:contracts"
+      paths:
+        - "packages/contracts/**"
+    - component_id: pkg-core
+      name: "pkg:core"
+      paths:
+        - "packages/core/**"
+    - component_id: pkg-memory
+      name: "pkg:memory"
+      paths:
+        - "packages/memory/**"
+    - component_id: pkg-mission-control
+      name: "pkg:mission-control"
+      paths:
+        - "packages/mission-control/**"
+    - component_id: pkg-plugin-claude
+      name: "pkg:plugin-claude"
+      paths:
+        - "packages/plugin-claude/**"
+    - component_id: pkg-plugin-http
+      name: "pkg:plugin-http"
+      paths:
+        - "packages/plugin-http/**"
+    - component_id: pkg-plugin-shell
+      name: "pkg:plugin-shell"
+      paths:
+        - "packages/plugin-shell/**"
+    - component_id: pkg-sdk-js
+      name: "pkg:sdk-js"
+      paths:
+        - "packages/sdk-js/**"
+    - component_id: pkg-viewer
+      name: "pkg:viewer"
+      paths:
+        - "packages/viewer/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Codecov configuration for X-Skynet
+# Docs: https://docs.codecov.com/docs/codecovyml-reference
+
+# Do not post a PR comment; rely on GitHub Checks instead
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        # Keep current overall coverage from regressing too much
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        # Require reasonable coverage on changed lines in PRs
+        target: 80%
+        threshold: 1%
+        only_pulls: true
+
+# Carry forward previous flag results when some flags are missing in a run
+# (useful with matrix builds)
+flag_management:
+  default_rules:
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,9 +11,20 @@ coverage:
         # Keep current overall coverage from regressing too much
         target: auto
         threshold: 2%
+      # Example per-flag project gate scoped to CI flag 'node-20.x'
+      node-20:
+        flags: ["node-20.x"]
+        target: auto
+        threshold: 2%
     patch:
       default:
         # Require reasonable coverage on changed lines in PRs
+        target: 80%
+        threshold: 1%
+        only_pulls: true
+      # Example per-flag patch gate scoped to CI flag 'node-20.x'
+      node-20:
+        flags: ["node-20.x"]
         target: 80%
         threshold: 1%
         only_pulls: true
@@ -23,3 +34,7 @@ coverage:
 flag_management:
   default_rules:
     carryforward: true
+  # Explicit example flag so it shows up in the Flags dashboard
+  individual_flags:
+    - name: "node-20.x"
+      carryforward: true

--- a/docs/ci-status-checks.md
+++ b/docs/ci-status-checks.md
@@ -1,90 +1,123 @@
-# CI Coverage & Status Checks
+# CI status checks and Codecov coverage gates
 
-This document explains the required status checks on `main`, how Codecov is configured, how to reproduce coverage locally, and how to troubleshoot common issues.
+This document explains the status checks we enforce on pull requests and how our Codecov coverage gates work. It also shows how to enable the required checks in GitHub branch protection and how to troubleshoot common issues.
 
-## Required checks on `main`
+> Scope: Repository `ds0857/x-skynet` (pnpm monorepo, Node.js 20). CI defined in `.github/workflows/ci.yml`. Coverage uploaded to Codecov using OIDC (`codecov/codecov-action@v4`).
 
-Branch protection enforces these checks before merging to `main`:
+## Required status checks for PRs
 
-- CI / build-test (20.x)
-- codecov/project — overall coverage gate
-- codecov/patch — changed-lines (patch) coverage gate
+Branch protection should require specific checks to pass before merging. The exact names shown in GitHub can vary slightly (matrix labels, flags). When adding checks, type "codecov" in the selector to see all relevant entries and pick the ones listed below.
 
-If any of these fail, the PR cannot be merged until the issue is resolved.
+Recommended required checks (global + per-package components):
 
-## Codecov configuration (codecov.yml)
+- CI job(s)
+  - build-test (Node 20.x) – our main CI job that runs lint, typecheck, tests, and uploads coverage
+- Codecov checks
+  - Global checks
+    - codecov/patch – validates coverage on changed lines in the PR
+    - codecov/project – protects overall project coverage from regressing beyond allowed threshold
+    - If flag-specific checks appear (e.g., `codecov/patch/node-20.x`, `codecov/project/node-20.x`), select those as well
+  - Component checks (per package; appear after first run with codecov.yml components)
+    - codecov/components/pkg-core/patch
+    - codecov/components/pkg-core/project
+    - codecov/components/pkg-cli/patch
+    - codecov/components/pkg-cli/project
+    - ... similarly for other packages under packages/\*
+
+Optional but recommended repository setting:
+
+- Require branches to be up to date before merging (ensures PR head includes latest base branch changes)
+
+## Codecov configuration (coverage gates)
+
+We configure Codecov gates in `codecov.yml`:
+
+```yaml
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+        only_pulls: true
+```
 
 Key points:
 
-- Project coverage gate uses `target: auto` with a 2% regression threshold.
-- Patch coverage gate requires `target: 80%` on changed lines.
-- Per-flag example gates are included for the CI flag `node-20.x` so you can scope checks to specific uploads when we expand the matrix.
-- Carryforward is enabled so missing flags don’t fail a run when using a build matrix.
+- Project gate: `target: auto` follows the current baseline coverage; merges fail if overall coverage drops by > 2%.
+- Patch gate: requires at least 80% coverage on changed lines for PRs, with a 1% threshold to absorb minor noise.
+- Flags: We also define a `node-20.x` flag so per-flag checks may show up (useful for matrix builds). Missing flags are carried forward to stabilize statuses.
 
-See `./codecov.yml` for the exact configuration.
+Flag settings excerpt:
 
-## CI upload and flags
-
-The GitHub Actions workflow uploads coverage using Codecov Action v4 with OIDC (no token needed for public repos):
-
-```
-- name: Upload coverage to Codecov via OIDC
-  if: always()
-  uses: codecov/codecov-action@v4
-  with:
-    use_oidc: true
-    files: coverage/lcov.info
-    flags: node-${{ matrix.node-version }}
-    fail_ci_if_error: false
+```yaml
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: "node-20.x"
+      carryforward: true
 ```
 
-For the current matrix, the flag is `node-20.x`. In Codecov’s UI and the PR’s Checks tab, you should see the flag appear under Codecov details.
+## Enabling required checks in GitHub
 
-## Reproducing locally
+1. Go to: GitHub → Settings → Branches → Branch protection rules → Edit (or Add rule for `main`).
+2. Enable “Require status checks to pass before merging”.
+3. Click “Search for checks” and add the following:
+   - `build-test` (or the job label shown for Node 20.x)
+   - `codecov/patch`
+   - `codecov/project`
+   - Any flag-specific Codecov checks if present (e.g., `/node-20.x`).
+4. (Optional) Enable “Require branches to be up to date before merging”.
+5. Save changes.
 
-1. Install dependencies and run tests with coverage:
+Screenshots (placeholders):
 
-```
-pnpm install
-pnpm test
-```
+- [ ] Screenshot: Branch protection → Require status checks to pass → selected checks
+- [ ] Screenshot: Codecov checks as seen in a PR (Checks tab)
 
-2. Inspect the generated report at `coverage/lcov.info`.
+## CI overview
 
-3. Optional: to preview what Codecov would upload, verify the file exists and is non-empty:
+Our CI workflow (`.github/workflows/ci.yml`) runs on Ubuntu with Node 20.x and performs:
 
-```
-ls -lh coverage/lcov.info
-```
+- Lint: `pnpm lint`
+- Typecheck: `pnpm typecheck`
+- Test with coverage: `pnpm test` (outputs `coverage/lcov.info`)
+- Upload coverage to Codecov via OIDC using `codecov/codecov-action@v4`
 
-Note: Local uploads to Codecov are not required; CI handles official uploads.
+The upload step is marked `if: always()` and uses `fail_ci_if_error: false` to avoid masking test failures with upload errors. Codecov still reports PR status checks based on the uploaded report.
+
+## Local development
+
+- Run tests with coverage: `pnpm test`
+- If you add new code, add or update tests to keep patch coverage ≥ 80%.
+- If CI reports a patch coverage shortfall:
+  - Add tests for uncovered lines in the PR
+  - If lines are intentionally untestable, consider refactoring to isolate them or mark them with `/* istanbul ignore next */` sparingly
 
 ## Troubleshooting
 
-- Missing Codecov checks on PRs:
-  - Ensure the workflow step uses `codecov/codecov-action@v4` with `use_oidc: true`.
-  - Confirm that `coverage/lcov.info` exists after tests.
-  - For private repos, set `CODECOV_TOKEN` as a repository secret and omit `use_oidc`, or keep OIDC if the app is installed and properly authorized.
-- Flags not showing:
-  - Verify the `flags:` input is set (e.g., `node-20.x`).
-  - With carryforward enabled, previous flag results may be used when a flag is missing, but the first successful upload must include the flag to establish it.
-- Patch status failing while project passes:
-  - Patch gates are stricter; add tests for changed lines or reduce uncovered additions.
-- YAML not applying:
-  - Confirm the file is named `codecov.yml` at the repo root.
-  - Check the Codecov UI settings to ensure repo-level YAML isn’t being overridden.
+- Codecov status check missing in PR:
+  - Confirm CI produced `coverage/lcov.info` and the upload step ran
+  - Check Codecov dashboard for the commit to see processing results
+- “Project coverage decreased” failure:
+  - Add or adjust tests to bring overall coverage back within the 2% threshold
+  - Consider splitting large refactors into smaller PRs with tests
+- Matrix or flag-related flakiness:
+  - Ensure flags are consistent across jobs; `carryforward: true` reduces transient failures
 
-## Adjusting branch protection (GitHub UI)
+## References
 
-Settings → Branches → Branch protection rules → Edit `main`:
+- Repository Codecov dashboard: https://app.codecov.io/gh/ds0857/x-skynet
+- Codecov YAML reference: https://docs.codecov.com/docs/codecovyml-reference
+- GitHub branch protection rules: https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/using-branch-protection-rules
 
-- Require a pull request before merging: enabled (recommended)
-- Require status checks to pass before merging: enabled
-- Select required checks:
-  - `CI / build-test (20.x)`
-  - `codecov/project`
-  - `codecov/patch`
-- Require branches to be up to date before merging: optional (recommended)
-- Include administrators: optional
+---
 
-Save changes.
+Change log
+
+- 2026-02-23: Initial draft documenting required checks and coverage gates; placeholders added for screenshots.

--- a/docs/ci-status-checks.md
+++ b/docs/ci-status-checks.md
@@ -1,0 +1,90 @@
+# CI Coverage & Status Checks
+
+This document explains the required status checks on `main`, how Codecov is configured, how to reproduce coverage locally, and how to troubleshoot common issues.
+
+## Required checks on `main`
+
+Branch protection enforces these checks before merging to `main`:
+
+- CI / build-test (20.x)
+- codecov/project — overall coverage gate
+- codecov/patch — changed-lines (patch) coverage gate
+
+If any of these fail, the PR cannot be merged until the issue is resolved.
+
+## Codecov configuration (codecov.yml)
+
+Key points:
+
+- Project coverage gate uses `target: auto` with a 2% regression threshold.
+- Patch coverage gate requires `target: 80%` on changed lines.
+- Per-flag example gates are included for the CI flag `node-20.x` so you can scope checks to specific uploads when we expand the matrix.
+- Carryforward is enabled so missing flags don’t fail a run when using a build matrix.
+
+See `./codecov.yml` for the exact configuration.
+
+## CI upload and flags
+
+The GitHub Actions workflow uploads coverage using Codecov Action v4 with OIDC (no token needed for public repos):
+
+```
+- name: Upload coverage to Codecov via OIDC
+  if: always()
+  uses: codecov/codecov-action@v4
+  with:
+    use_oidc: true
+    files: coverage/lcov.info
+    flags: node-${{ matrix.node-version }}
+    fail_ci_if_error: false
+```
+
+For the current matrix, the flag is `node-20.x`. In Codecov’s UI and the PR’s Checks tab, you should see the flag appear under Codecov details.
+
+## Reproducing locally
+
+1. Install dependencies and run tests with coverage:
+
+```
+pnpm install
+pnpm test
+```
+
+2. Inspect the generated report at `coverage/lcov.info`.
+
+3. Optional: to preview what Codecov would upload, verify the file exists and is non-empty:
+
+```
+ls -lh coverage/lcov.info
+```
+
+Note: Local uploads to Codecov are not required; CI handles official uploads.
+
+## Troubleshooting
+
+- Missing Codecov checks on PRs:
+  - Ensure the workflow step uses `codecov/codecov-action@v4` with `use_oidc: true`.
+  - Confirm that `coverage/lcov.info` exists after tests.
+  - For private repos, set `CODECOV_TOKEN` as a repository secret and omit `use_oidc`, or keep OIDC if the app is installed and properly authorized.
+- Flags not showing:
+  - Verify the `flags:` input is set (e.g., `node-20.x`).
+  - With carryforward enabled, previous flag results may be used when a flag is missing, but the first successful upload must include the flag to establish it.
+- Patch status failing while project passes:
+  - Patch gates are stricter; add tests for changed lines or reduce uncovered additions.
+- YAML not applying:
+  - Confirm the file is named `codecov.yml` at the repo root.
+  - Check the Codecov UI settings to ensure repo-level YAML isn’t being overridden.
+
+## Adjusting branch protection (GitHub UI)
+
+Settings → Branches → Branch protection rules → Edit `main`:
+
+- Require a pull request before merging: enabled (recommended)
+- Require status checks to pass before merging: enabled
+- Select required checks:
+  - `CI / build-test (20.x)`
+  - `codecov/project`
+  - `codecov/patch`
+- Require branches to be up to date before merging: optional (recommended)
+- Include administrators: optional
+
+Save changes.

--- a/docs/cli-agents.md
+++ b/docs/cli-agents.md
@@ -1,0 +1,77 @@
+# CLI: agents subcommand (preview)
+
+Status: Experimental in Phase 2. This document captures the intended UX and flags so early adopters can prepare scripts and tooling. Implementation will land incrementally.
+
+## Overview
+
+The `xskynet agents` family of commands is the primary CLI surface for:
+- Listing available agents in your app
+- Running an agent with an input and capturing outputs
+- Inspecting runs and tailing logs
+
+Target design goals:
+- One-liner to run any agent in your workspace
+- Deterministic runs with reproducible inputs/outputs
+- First-class, structured logs with run/task/step correlation IDs
+
+## Commands (planned)
+
+- `xskynet agents list`
+  - Discover agents exported by your app (or a template)
+  - Output: table or JSON (`--output json`)
+
+- `xskynet agents run <agent-name> [--input <path>|--stdin]`
+  - Execute the specified agent with provided input
+  - Persists a Run record (ID, status, timestamps)
+  - Emits structured logs; artifacts saved to `.xskynet/runs/<runId>/`
+
+- `xskynet agents show <run-id>`
+  - Print run metadata, status, and artifacts
+  - `--output json` for machine consumption
+
+- `xskynet agents logs <run-id> [--follow]`
+  - Stream or print logs for a run
+  - Supports filtering by level/module
+
+## Common flags
+
+- `--log-level <level>`: trace | debug | info | warn | error (default: info)
+- `--log-format <format>`: json | pretty (default: pretty in TTY, json otherwise)
+- `--log-file <path>`: also tee logs to a file
+- `--output <format>`: table | json (for list/show)
+- `--cwd <path>`: working directory for agent resolution
+
+Environment variables (fallbacks):
+- `XSKYNET_LOG_LEVEL`
+- `XSKYNET_LOG_FORMAT`
+- `XSKYNET_LOG_FILE`
+
+## Examples
+
+List agents:
+
+```bash
+xskynet agents list --output table
+```
+
+Run an agent with JSON input from a file and verbose logs:
+
+```bash
+xskynet agents run researcher --input input.json --log-level debug --log-format json
+```
+
+Tail logs for a run:
+
+```bash
+xskynet agents logs <runId> --follow --log-level info
+```
+
+## Exit codes
+- 0: success
+- 1: runtime error (agent failed)
+- 2: invalid input/flags
+- 3: not found (agent or run)
+
+## Notes
+- The CLI is a thin orchestration layer that uses SDK contracts from `@xskynet/contracts` and engine facilities from `@xskynet/core`.
+- Logging behavior is described in detail in docs/logging.md.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,58 @@
+# Logging and Run Correlation (preview)
+
+This document describes the logging model used by the CLI and runtime to provide high‑signal, queryable traces of agent activity.
+
+## Goals
+- Human‑readable by default, structured when needed
+- Correlate logs across Run → Task → Step
+- Support real‑time tailing and post‑hoc analysis
+
+## Log levels
+- trace: very noisy internal events
+- debug: development diagnostics
+- info: normal operational messages
+- warn: unexpected but non‑fatal
+- error: failures and user‑visible errors
+
+## Formats
+- pretty: colorized, aligned columns, for terminals
+- json: newline‑delimited JSON objects, each with a consistent schema
+
+## Core fields (JSON)
+- timestamp (ISO‑8601)
+- level (trace|debug|info|warn|error)
+- module (string)
+- runId (string)
+- taskId (string | optional)
+- stepId (string | optional)
+- message (string)
+- data (object | optional)
+
+## Emission points
+- CLI command handlers (argument parsing, validation, I/O)
+- Engine events (domain events from @xskynet/core)
+- Plugin executors (plugin‑specific diagnostics)
+
+## Configuration
+Configured via flags or env vars:
+- --log-level / XSKYNET_LOG_LEVEL
+- --log-format / XSKYNET_LOG_FORMAT
+- --log-file / XSKYNET_LOG_FILE
+
+When --log-file is set, logs are tee’d to the specified path and stdout. JSON format is recommended when shipping to log collectors.
+
+## Storage
+- Each run writes an index under `.xskynet/runs/<runId>/`
+- `logs.ndjson` contains the structured log stream
+- Artifacts and metadata live alongside logs for reproducibility
+
+## Tailing
+The CLI will support `xskynet agents logs <runId> --follow` which:
+- Subscribes to the run’s event bus
+- Formats and prints incoming log records
+- Supports level filtering to reduce noise
+
+## Future work
+- Source maps and linkable errors for better DX
+- OpenTelemetry exporter
+- Per‑module verbosity controls

--- a/shared/ASSIGNMENTS.md
+++ b/shared/ASSIGNMENTS.md
@@ -1,0 +1,43 @@
+# X-Skynet Assignments v0.1
+
+Status: Draft
+Owner: Mute (Deputy GM)
+Last Updated: 2026-02-23
+
+## Roles
+
+- CEO (minion): Vision, product direction, approvals
+- Deputy GM (Mute): Execution lead, architecture, delivery
+- Research (scout/sage): Competitive analysis, API research
+- Content (quill): Docs, tutorials, examples
+- Engineering (xalt): Core engine, plugins, tooling
+- QA (observer): Tests, CI, coverage, release checks
+
+## Responsibility Matrix (RACI)
+
+| Area                        | CEO | Deputy GM | Engineering | Research | Content | QA  |
+| --------------------------- | --- | --------- | ----------- | -------- | ------- | --- |
+| Contracts design            | A   | R         | C           | C        | I       | I   |
+| Core executor               | I   | A         | R           | I        | I       | C   |
+| Plugins (claude/http/shell) | I   | A         | R           | C        | I       | C   |
+| CLI                         | I   | A         | R           | I        | C       | C   |
+| Viewer                      | I   | A         | R           | I        | C       | C   |
+| Docs site                   | A   | C         | I           | I        | R       | C   |
+| Examples                    | A   | C         | R           | C        | R       | C   |
+| CI/QA                       | I   | A         | C           | I        | I       | R   |
+
+Legend: R=Responsible, A=Accountable, C=Consulted, I=Informed
+
+## Interfaces / Points of Contact
+
+- Architecture questions → Deputy GM (Mute)
+- Engine/Plugin implementation → Engineering (xalt)
+- Docs/tutorials → Content (quill)
+- Research spikes → Research (scout/sage)
+- QA/Release → QA (observer)
+
+## Near-term Task Matrix (Phase 1)
+
+- Repo hygiene and scripts — Engineering (R), Deputy GM (A)
+- Quickstart + README — Content (R), Deputy GM (A)
+- Basic tests scaffold — QA (R), Engineering (C), Deputy GM (A)

--- a/shared/DEVELOPMENT_PLAN.md
+++ b/shared/DEVELOPMENT_PLAN.md
@@ -1,0 +1,73 @@
+# X-Skynet Development Plan v0.1
+
+Status: Draft
+Owner: Mute (Deputy GM)
+Last Updated: 2026-02-23
+
+## Phase Overview
+
+- Phase 1 — Bootstrap & Foundations (Week 1)
+  - Repo hygiene, monorepo wiring, CI skeleton, docs seed
+- Phase 2 — Core Engine & Contracts (Weeks 2-3)
+  - Stable task/plan contracts, minimal executor, plugin API
+- Phase 3 — CLI, Plugins, and Viewer (Weeks 3-4)
+  - CLI UX, built-in plugins (claude/http/shell), run viewer
+- Phase 4 — Reliability, Docs, and Examples (Weeks 4-5)
+  - Observability, test coverage, examples, release process
+
+## Milestones & Deliverables
+
+1. M1: Repo Ready (end of Phase 1)
+
+- Deliverables:
+  - pnpm monorepo configured with TS project references
+  - Lint, format, typecheck scripts passing
+  - CI: lint + test + typecheck on PR; codecov upload
+  - Docs: Quickstart, contribution guide skeleton
+- Acceptance:
+  - `pnpm i && pnpm typecheck && pnpm test` succeeds locally and in CI
+
+2. M2: Contracts & Minimal Engine (mid Phase 2)
+
+- Deliverables:
+  - @xskynet/contracts: Plan, Task, Step types with clear state model
+  - @xskynet/core: Minimal executor that can run a simple plan
+  - Example in apps/demo showing plan execution
+- Acceptance:
+  - A sample plan with 3 steps runs deterministically; unit tests cover state transitions
+
+3. M3: CLI & Essential Plugins (end Phase 3)
+
+- Deliverables:
+  - @xskynet/cli: `xsk plan run`, `xsk task list` basic commands
+  - Plugins: claude, http, shell with typed interfaces
+  - Viewer app renders DAG and step logs
+- Acceptance:
+  - Run a plan via CLI using plugins; viewer shows the run graph and logs
+
+4. M4: Reliability & Docs (end Phase 4)
+
+- Deliverables:
+  - Tracing hooks, structured logs, retry policy, idempotency keys
+  - Examples: multi-agent workflow, web-crawl workflow
+  - Docs site pages: Architecture, Contracts, Plugins, CLI, Viewer
+- Acceptance:
+  - > 80% statement coverage across core and contracts; examples run end-to-end
+
+## Timeline (tentative)
+
+- Week 1: Phase 1
+- Weeks 2-3: Phase 2
+- Weeks 3-4: Phase 3
+- Weeks 4-5: Phase 4
+
+## Risks & Mitigations
+
+- Scope creep: track via issues and PRs; milestone gates
+- API churn: version contracts and mark experimental symbols
+- Cross-package builds: enforce references and CI matrix
+
+## Tracking
+
+- Issues and milestones in GitHub
+- CI via GitHub Actions (to be added)


### PR DESCRIPTION
## Summary
- Enforce Codecov project (auto±2%) and patch (80%) status checks via codecov.yml
- Add per-flag example for node-20.x; enable carryforward for matrix builds
- Document checks, local reproduction, and troubleshooting in docs/ci-status-checks.md

## Test plan
- CI should upload coverage with flag node-20.x and show Codecov checks
- Branch protection can require `codecov/project` and `codecov/patch`

🤖 Generated with Claude Code