### PR TITLE
docs: promote DEVELOPMENT_PLAN & ASSIGNMENTS to v1.0; index shared/ with policy links

### DIFF
--- a/docs/ASSIGNMENTS.md
+++ b/docs/ASSIGNMENTS.md
@@ -1,8 +1,8 @@
-# X-Skynet Assignments v0.1 (Public)
+# X-Skynet Assignments v1.0 (Public)
 
 Status: Draft
 Owner: Mute (Deputy GM)
-Last Updated: 2026-02-23
+Last Updated: 2026-02-25
 
 This is the public-facing mirror of the assignments maintained in shared/.
 

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -1,8 +1,8 @@
-# X-Skynet Development Plan v0.1
+# X-Skynet Development Plan v1.0
 
 Status: Draft
 Owner: Mute (Deputy GM)
-Last Updated: 2026-02-23
+Last Updated: 2026-02-25
 
 This is the public-facing mirror of the living plan in shared/.
 

--- a/shared/ASSIGNMENTS.md
+++ b/shared/ASSIGNMENTS.md
@@ -1,25 +1,25 @@
 ---
 # id: Stable unique identifier for this doc (do not change)
-id: assignments-v0-1
+id: assignments-v1-0
 # title: Human-readable title
-title: X-Skynet Assignments v0.1
+title: X-Skynet Assignments v1.0
 # status: draft | review | approved
-status: draft
+status: review
 # owner: Primary accountable owner
 owner: Mute (Deputy GM)
 # lastUpdated: YYYY-MM-DD
-lastUpdated: 2026-02-24
+lastUpdated: 2026-02-25
 # version: Document version, not product
-version: 0.1
+version: 1.0
 # approvalGate: Required label/gate before merging updates
 approvalGate: approved-by-nova
 ---
 
-# X-Skynet Assignments v0.1
+# X-Skynet Assignments v1.0
 
-Status: Draft
+Status: Review
 Owner: Mute (Deputy GM)
-Last Updated: 2026-02-24
+Last Updated: 2026-02-25
 
 Approval: Pending — requires 'approved-by-nova' sign-off.
 
@@ -28,11 +28,11 @@ Approval: Pending — requires 'approved-by-nova' sign-off.
 - [Roles](#roles)
 - [Responsibility Matrix (RACI)](#responsibility-matrix-raci)
 - [Phase 1 Task Owners（P1-04/06/07/08）](#phase-1-task-ownersp1-04060708)
+- [Phase 2–4 Ownership](#phase-2–4-ownership)
 - [Interfaces / Points of Contact](#interfaces--points-of-contact)
 - [SLAs](#slas)
-- [Near-term Task Matrix (Phase 1)](#near-term-task-matrix-phase-1)
+- [Acceptance Authority](#acceptance-authority)
 - [References](#references)
-- [TODOs](#todos)
 
 ## Roles
 
@@ -65,6 +65,16 @@ Legend: R=Responsible, A=Accountable, C=Consulted, I=Informed
 - P1-07 Basic tests scaffold — QA (observer) R, Engineering (xalt) C, Deputy GM (Mute) A
 - P1-08 CI skeleton — Engineering (xalt) R, QA (observer) C, Deputy GM (Mute) A
 
+## Phase 2–4 Ownership
+
+- Contracts & minimal executor — Engineering (xalt) R, Deputy GM (Mute) A, QA (observer) C
+- Plugin SDK & built‑ins — Engineering (xalt) R, Deputy GM (Mute) A, Research (scout/sage) C
+- CLI — Engineering (xalt) R, Deputy GM (Mute) A, Content (quill) C
+- Viewer — Engineering (xalt) R, Deputy GM (Mute) A, Content (quill) C
+- Observability & hardening — Engineering (xalt) R, Deputy GM (Mute) A, QA (observer) R (testing)
+- Docs & examples — Content (quill) R, Deputy GM (Mute) A, Engineering (xalt) C
+- Release process — Deputy GM (Mute) R/A, QA (observer) C
+
 ## Interfaces / Points of Contact
 
 - Architecture questions → Deputy GM (Mute)
@@ -79,18 +89,10 @@ Legend: R=Responsible, A=Accountable, C=Consulted, I=Informed
 - Docs/Quickstart updates: within 24h of significant API change
 - CI breakages: triage within 2h, fix within 24h
 
-## Near-term Task Matrix (Phase 1)
+## Acceptance Authority
 
-- Repo hygiene and scripts — Engineering (R), Deputy GM (A)
-- Quickstart + README — Content (R), Deputy GM (A)
-- Basic tests scaffold — QA (R), Engineering (C), Deputy GM (A)
-- CI skeleton — Engineering (R), QA (C), Deputy GM (A)
-
-## TODOs
-
-- [ ] Map Phase 2 owners for contracts/core/CLI/plugins
-- [ ] Add backup approvers for each area
-- [ ] Define escalation rules for CI breakages
+- Phase 1 deliverables — Deputy GM (Mute) verifies criteria; QA (observer) signs off tests/CI
+- Phase 2–4 deliverables — Deputy GM (Mute) as final gate; CEO (minion) optional approval for milestone exits
 
 ## References
 
@@ -98,4 +100,3 @@ Legend: R=Responsible, A=Accountable, C=Consulted, I=Informed
 - Development plan (public mirror): ../docs/DEVELOPMENT_PLAN.md
 - Release readiness checklist: ../docs/release-readiness.md
 - CI status checks and Codecov gates: ../docs/ci-status-checks.md
-- RFC-0002: Contracts (types): ../packages/contracts/src/index.ts

--- a/shared/DEVELOPMENT_PLAN.md
+++ b/shared/DEVELOPMENT_PLAN.md
@@ -2,24 +2,24 @@
 # id: Stable unique identifier for this doc (do not change)
 id: development-plan-v0-1
 # title: Human-readable title
-title: X-Skynet Development Plan v0.1
+title: X-Skynet Development Plan v1.0
 # status: draft | review | approved
-status: draft
+status: review
 # owner: Primary accountable owner
 owner: Mute (Deputy GM)
 # lastUpdated: YYYY-MM-DD
-lastUpdated: 2026-02-24
+lastUpdated: 2026-02-25
 # version: Document version, not product
-version: 0.1
+version: 1.0
 # approvalGate: Required label/gate before merging updates
 approvalGate: approved-by-nova
 ---
 
-# X-Skynet Development Plan v0.1
+# X-Skynet Development Plan v1.0
 
-Status: Draft
+Status: Review
 Owner: Mute (Deputy GM)
-Last Updated: 2026-02-24
+Last Updated: 2026-02-25
 
 Approval: Pending — requires 'approved-by-nova' sign-off.
 
@@ -27,13 +27,15 @@ Approval: Pending — requires 'approved-by-nova' sign-off.
 
 - [Phase Overview](#phase-overview)
 - [Phase 1 Detailed Tasks (P1-04/06/07/08)](#phase-1-detailed-tasks-p1-04060708)
+- [Phase 2 Detailed Tasks](#phase-2-detailed-tasks)
+- [Phase 3 Detailed Tasks](#phase-3-detailed-tasks)
+- [Phase 4 Detailed Tasks](#phase-4-detailed-tasks)
 - [Milestones & Deliverables](#milestones--deliverables)
-- [Timeline (tentative)](#timeline-tentative)
+- [Dependencies & Assumptions](#dependencies--assumptions)
 - [Risks & Mitigations](#risks--mitigations)
+- [Timeline (tentative)](#timeline-tentative)
 - [Tracking](#tracking)
 - [References](#references)
-- [TODOs](#todos)
-- [Templates](#templates)
 
 ## Phase Overview
 
@@ -54,7 +56,7 @@ Below are the Phase 1 tasks with scope, estimates, and acceptance criteria.
 
 - Scope（范围）
   - Root scripts for build, typecheck, lint, test, dev
-  - Enforce Node.js engine (>=20.11), Volta pin
+  - Enforce Node.js engine (>=20.11)
   - Prettier, ESLint wiring; shared config packages
   - Husky + lint-staged pre-commit hooks
 - Estimate（预估）: 0.5–1.0 day
@@ -68,7 +70,7 @@ Below are the Phase 1 tasks with scope, estimates, and acceptance criteria.
 ### P1-06 — Quickstart + README（快速开始与首页文档）
 
 - Scope（范围）
-  - docs/Quickstart.md: 15-min path to first running agent
+  - docs/Quickstart.md: 15‑min path to first running agent
   - README: repository structure, scripts, contribution pointers
   - Ensure demo and CLI notes are discoverable
 - Estimate（预估）: 0.5 day
@@ -100,6 +102,120 @@ Below are the Phase 1 tasks with scope, estimates, and acceptance criteria.
   - [ ] All jobs pass with current codebase
   - [ ] Coverage artifact uploaded; badge visible in README (optional)
 
+## Phase 2 Detailed Tasks
+
+### P2-01 — Contracts v1（计划/任务/步骤 类型契约）
+
+- Scope
+  - Define stable Typescript types: Plan, Task, Step, Run, Status, Result
+  - Document state transitions and invariants (DAG, success/failure semantics)
+  - Export from `@xskynet/contracts`
+- Acceptance
+  - [ ] Public types exported with TSD tests (tsd/ or dtslint‑style)
+  - [ ] State transition diagram checked into docs (ASCII or mermaid)
+  - [ ] Versioned: mark experimental where needed; semver noted
+
+### P2-02 — Minimal executor（最小执行器）
+
+- Scope
+  - Deterministic DAG walker with serial + simple parallel lanes
+  - Step lifecycle: prepare → execute → finalize
+  - Cancellation, timeout, and basic retry loop
+- Acceptance
+  - [ ] Run a 3‑step demo plan from examples/
+  - [ ] Unit tests cover success, failure, cancel paths
+  - [ ] Structured logs (level, ts, runId, stepId)
+
+### P2-03 — Plugin SDK & registry（插件 SDK 与注册表）
+
+- Scope
+  - Plugin interface: `init(ctx)`, `execute(step, ctx)`, hooks
+  - Context contract: IO, logging, secrets, cancellation token
+  - In‑process registry for resolving plugin by name
+- Acceptance
+  - [ ] Example plugins load via name (shell/http mock)
+  - [ ] SDK documented in docs/cli-agents.md (or new SDK page)
+  - [ ] Type tests validate plugin contracts
+
+### P2-04 — Error model & retry semantics（错误模型与重试）
+
+- Scope
+  - Error taxonomy: retriable, fatal, user, infra
+  - Backoff policy (exponential + jitter), max attempts, idempotency notes
+  - Surface to CLI and logs with structured fields
+- Acceptance
+  - [ ] Unit tests for retryable vs fatal branches
+  - [ ] Docs contain guidance for plugin authors
+
+### P2-05 — Run persistence (MVP)（运行持久化）
+
+- Scope
+  - In‑memory store with JSON snapshot export/import
+  - Interface abstracted for future adapters (FS/DB)
+- Acceptance
+  - [ ] CLI can export/import a run snapshot
+  - [ ] Tests verify snapshot round‑trip
+
+## Phase 3 Detailed Tasks
+
+### P3-01 — CLI MVP（命令行工具）
+
+- Scope
+  - `@xskynet/cli` with commands: `xsk plan run`, `xsk task list`, `xsk run inspect`
+  - Config discovery, workspace awareness, colored logs
+- Acceptance
+  - [ ] Run demo plan via CLI
+  - [ ] Help output and examples present
+
+### P3-02 — Built‑in plugins（内置插件）
+
+- Scope
+  - `shell` plugin: spawn commands with timeouts
+  - `http` plugin: fetch/POST with json, headers, retries
+  - `claude` plugin: adapter skeleton with provider‑agnostic interface
+- Acceptance
+  - [ ] Example plan uses at least two plugins
+  - [ ] Unit tests for each plugin happy path and failure path
+
+### P3-03 — Run Viewer（运行可视化）
+
+- Scope
+  - Minimal TUI or web viewer to render DAG and step logs
+  - Link from CLI to open viewer
+- Acceptance
+  - [ ] Viewer renders DAG from snapshot
+  - [ ] Works locally across platforms (macOS/Linux; Windows best‑effort)
+
+## Phase 4 Detailed Tasks
+
+### P4-01 — Observability & hardening（可观测性与加固）
+
+- Scope
+  - Tracing hooks and correlation IDs
+  - Structured logs, redaction rules for secrets
+  - Retry, idempotency, and cancellation verified in stress tests
+- Acceptance
+  - [ ] > 80% statement coverage across core and contracts
+  - [ ] Load test shows stable behavior with 50 concurrent steps
+
+### P4-02 — Docs & examples（文档与示例）
+
+- Scope
+  - Expand docs site; end‑to‑end examples under examples/
+  - Contributor guide updates; release checklist
+- Acceptance
+  - [ ] Quickstart runs green against v1 engine/CLI
+  - [ ] Examples pass in CI
+
+### P4-03 — Release process（发布流程）
+
+- Scope
+  - Release‑it config, changelog, tags, semver policy
+  - Codecov gates enforced; branch protections updated
+- Acceptance
+  - [ ] Dry‑run release works end‑to‑end
+  - [ ] PR template and CI checks in place
+
 ## Milestones & Deliverables
 
 1. M1: Repo Ready (end of Phase 1)
@@ -107,56 +223,48 @@ Below are the Phase 1 tasks with scope, estimates, and acceptance criteria.
    - Acceptance: `pnpm i && pnpm typecheck && pnpm test` succeeds locally and in CI
 
 2. M2: Contracts & Minimal Engine (mid Phase 2)
-   - Deliverables: @xskynet/contracts (Plan/Task/Step types); @xskynet/core minimal executor; example demo
+   - Deliverables: `@xskynet/contracts` types; `@xskynet/core` minimal executor; example demo; plugin SDK v1
    - Acceptance: A sample plan with 3 steps runs deterministically; unit tests cover state transitions
 
 3. M3: CLI & Essential Plugins (end Phase 3)
-   - Deliverables: @xskynet/cli (`xsk plan run`, `xsk task list`); plugins (claude/http/shell); viewer app renders DAG + logs
+   - Deliverables: `@xskynet/cli` commands; plugins (claude/http/shell); viewer renders DAG + logs
    - Acceptance: Run a plan via CLI using plugins; viewer shows run graph and logs
 
 4. M4: Reliability & Docs (end Phase 4)
-   - Deliverables: Tracing hooks, structured logs, retry policy, idempotency; examples; docs site
-   - Acceptance: > 80% statement coverage across core and contracts; examples run end-to-end
+   - Deliverables: Tracing hooks, structured logs, retry policy, idempotency; examples; docs site and release scripts
+   - Acceptance: > 80% statement coverage across core and contracts; examples run end‑to‑end
 
-## Timeline (tentative)
+## Dependencies & Assumptions
 
-- Week 1: Phase 1 (P1-04/06/07/08)
-- Weeks 2-3: Phase 2
-- Weeks 3-4: Phase 3
-- Weeks 4-5: Phase 4
+- Tooling: Node 20.11+, pnpm 9.x, GitHub Actions runners (ubuntu‑latest)
+- Secrets management: Local env for dev; GH OIDC/Secrets for CI (no plaintext tokens in repo)
+- External services: Optional Codecov for coverage; LLM providers behind adapter; network egress in CI
+- OS targets: macOS/Linux primary; Windows best‑effort for CLI and shell plugin
 
 ## Risks & Mitigations
 
-- Scope creep: track via issues and PRs; milestone gates
-- API churn: version contracts and mark experimental symbols
-- Cross-package builds: enforce references and CI matrix
+- Scope creep
+  - Mitigation: Track via issues/milestones; gate merges behind milestones
+- API churn across packages
+  - Mitigation: Version contracts; mark experimental; document breaking changes
+- Cross‑package build/test complexity
+  - Mitigation: Enforce TypeScript project references; CI matrix; cache pnpm store
+- Provider limits and rate‑limits (LLM/http)
+  - Mitigation: Backoff policies; test with stub/mocks; offline fixtures
+- Security (token leakage in logs)
+  - Mitigation: Redaction rules; secret fields in context; review logging
+
+## Timeline (tentative)
+
+- Week 1: Phase 1 (P1‑04/06/07/08)
+- Weeks 2‑3: Phase 2
+- Weeks 3‑4: Phase 3
+- Weeks 4‑5: Phase 4
 
 ## Tracking
 
 - Issues and milestones in GitHub
-- CI via GitHub Actions (to be added)
-
-## Templates
-
-### Task Template (example)
-
-```
-### <PHASE>-<ID> — <Title>（中文标题）
-
-- Scope（范围）
-  - <bullet points>
-- Estimate（预估）: <days>
-- Acceptance（验收标准）
-  - [ ] <checkbox criteria>
-```
-
-### Milestone Template
-
-```
-- M<id>: <Milestone Name>
-  - Deliverables: <list>
-  - Acceptance: <acceptance summary>
-```
+- CI via GitHub Actions
 
 ## References
 
@@ -164,11 +272,5 @@ Below are the Phase 1 tasks with scope, estimates, and acceptance criteria.
 - Assignments (public mirror): ../docs/ASSIGNMENTS.md
 - Release readiness checklist: ../docs/release-readiness.md
 - CI status checks and Codecov gates: ../docs/ci-status-checks.md
-- RFC-0002: Contracts (types): ../packages/contracts/src/index.ts
-
-## TODOs
-
-- [ ] Phase 2 breakdown: contracts package structure and versioning strategy
-- [ ] Define plugin lifecycle hooks and error handling semantics
-- [ ] Add CI matrix for OS/Node versions
-- [ ] Mirror to docs/ on release via script
+- CLI agents design: ../docs/cli-agents.md
+- Contracts package (placeholder): ../packages/contracts/

--- a/shared/README.md
+++ b/shared/README.md
@@ -13,7 +13,10 @@ This directory contains cross-repo documents used by the team: plans, assignment
 
 ## Contents
 
-- DEVELOPMENT_PLAN.md — project phases and milestones
+- WHITEPAPER.md — project vision and principles
+- MEMORY-SYNC-POLICY.md — mandatory memory hygiene policy (Nova)
+
+- DEVELOPMENT_PLAN.md — project phases and milestones (authoritative; public mirror in docs/)
 - ASSIGNMENTS.md — roles, RACI, SLAs
 - STYLE.md — style rules for shared/ docs (frontmatter, IDs)
 


### PR DESCRIPTION
## Summary
- Promote shared/DEVELOPMENT_PLAN.md to v1.0 with full Phase 1–4 breakdown, dependencies, risks, and deliverables; sync docs/ mirror titles/timestamps
- Promote shared/ASSIGNMENTS.md to v1.0 with RACI, Phase 2–4 ownership, acceptance authority; sync docs/ mirror
- Update shared/README.md to index WHITEPAPER.md and MEMORY-SYNC-POLICY.md; clarify authoritative mirrors

## Rationale
Brings the public plan and assignments in line with WHITEPAPER and MEMORY-SYNC-POLICY. Establishes clear gates and owners for Phase 1–4, supporting execution and accountability.

## Scope
Docs only: shared/, docs/

## Checklist
- [x] Frontmatter present and valid per shared/STYLE.md
- [x] Cross-links validated (relative paths)
- [x] No code or workflow changes

## Screenshots/Previews
N/A

## Risks
Low; documentation only.

🤖 Generated by Mute (Deputy GM)
