### PR TITLE
chore(docs): Phase 1 plan & governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,23 @@
-* @ds0857
-/packages/core/ @ds0857
-/packages/contracts/ @ds0857
+# Code ownership rules for X-Skynet
+# The last matching pattern takes the most precedence
+
+*                     @ds0857
+
+# Core modules
+/packages/core/       @ds0857
+/packages/contracts/  @ds0857
+/packages/cli/        @ds0857
+
+# Examples and templates
+/examples/            @ds0857
+/templates/           @ds0857
+
+# Documentation and site
+/docs/site/           @ds0857
+/shared/              @ds0857
+
+# Deployment and ops
+/deploy/              @ds0857
+
+# GitHub meta
+/.github/             @ds0857

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,37 @@
-## Description
-<!-- Please describe the changes in this PR -->
+## Summary
+<!-- What and why. Keep it short. -->
 
-## Testing
-<!-- Please describe how this was tested -->
+## Changes
+- [ ] Files/docs updated
+- [ ] Tests added/updated (if applicable)
+- [ ] DX/CI configs updated (if applicable)
 
-## Documentation
-<!-- Please describe any documentation updates -->
-- [ ] Documentation updated
-- [ ] No documentation changes needed
+## Linked Issues
+<!-- e.g. Closes #123 -->
+
+## Type
+- [ ] feat
+- [ ] fix
+- [ ] chore
+- [ ] docs
+- [ ] refactor
+- [ ] perf
+- [ ] test
+
+## Governance Checklist
+- [ ] Acceptance criteria listed in this PR body
+- [ ] Appropriate labels added (type, area)
+- [ ] Documentation updated or explicitly N/A
+- [ ] No secrets or large binaries committed
+- [ ] Changelog section updated if user-facing change
+- [ ] CI passes locally (lint/test/build) or rationale provided
+
+## Test Plan
+<!-- How did you test it? Include steps or screenshots if relevant. -->
 
 ## Breaking Changes
-<!-- Please check if this PR introduces any breaking changes -->
-- [ ] No breaking changes
-- [ ] Breaking changes present (please describe below)
+- [ ] No
+- [ ] Yes (describe impact and migration)
 
-## Checklist
-- [ ] Code follows project style guidelines
-- [ ] Self-review completed
-- [ ] Tests added/updated (if applicable)
-- [ ] No new warnings introduced
+## Risks & Mitigations
+<!-- Known risks and how we mitigate them -->

--- a/shared/ASSIGNMENTS.md
+++ b/shared/ASSIGNMENTS.md
@@ -1,0 +1,30 @@
+# X-Skynet Assignments
+
+Last updated: 2026-02-25
+Owner: Mute (Deputy GM)
+
+## Roles
+- CEO (minion): Vision, approvals, external comms
+- Deputy GM (Mute): Delivery lead, architecture, core development
+- Research (scout): Competitive analysis, docs research
+- QA (observer): Test plans, regression suites
+- Comms (quill): Docs site, announcements
+
+## Module Ownership
+
+| Area | Path | Owner |
+|------|------|-------|
+| Core runtime | packages/core/ | Mute |
+| Contracts/schema | packages/contracts/ | Mute |
+| CLI | packages/cli/ | Mute |
+| Examples | examples/* | Mute |
+| Docs site | docs/site/* | quill |
+| Deploy (helm/k8s) | deploy/* | Mute |
+
+## Operating Cadence
+- Daily: 30-minute progress update by Mute in private memory
+- Weekly: Review backlog and CODEOWNERS
+- PRs: Small, focused, with checklist completed
+
+## Backlog Link
+See shared/DEVELOPMENT_PLAN.md

--- a/shared/DEVELOPMENT_PLAN.md
+++ b/shared/DEVELOPMENT_PLAN.md
@@ -1,0 +1,41 @@
+# X-Skynet Development Plan
+
+Last updated: 2026-02-25
+Owner: Mute (Deputy GM)
+
+## Phase Overview
+- Phase 1: Foundation & Governance (Feb–Mar 2026)
+- Phase 2: Core Capabilities (Mar–Apr 2026)
+- Phase 3: Integrations & Scale (Apr–May 2026)
+- Phase 4: Community & Release (May 2026)
+
+## Phase 1 Backlog
+
+| ID | Work Item | Type | Owner | Status | Start | End | Notes |
+|---:|-----------|------|-------|--------|-------|-----|-------|
+| P1-01 | Repo hardening: CI, security, CODEOWNERS | Ops | @ds0857 | Done | — | — | Already present, verify coverage |
+| P1-02 | Governance: PR template, labels, release notes | Docs | Mute | Planned | 2026-02-25 | 2026-02-26 | Improve PR template checklist |
+| P1-03 | Engineering playbook: CONTRIBUTING.md, branching | Docs | Mute | Planned | 2026-02-26 | 2026-02-27 | Include commit/PR conventions |
+| P1-04 | Planning docs: shared/DEVELOPMENT_PLAN.md | Docs | Mute | In Progress | 2026-02-25 | 2026-02-25 | This document |
+| P1-05 | Roles & ownership: shared/ASSIGNMENTS.md | Docs | Mute | Planned | 2026-02-25 | 2026-02-25 | Map modules → owners |
+| P1-06 | Roadmap site updates (docs/site) | Docs | Mute | Planned | 2026-02-27 | 2026-02-28 | Sync with plan |
+| P1-07 | Release automation guardrails | Ops | Mute | Planned | 2026-02-28 | 2026-03-01 | Changelog, semantic versioning |
+| P1-08 | Sample agents polish (examples/*) | Dev | Mute | Planned | 2026-03-01 | 2026-03-03 | DX improvements, tests |
+
+## Milestones & Schedule (Phase 1)
+- 02/25: Create planning/governance docs (this PR)
+- 02/26: Add CONTRIBUTING.md + conventions
+- 02/27: Update website roadmap pages
+- 02/28–03/01: Release guardrails
+- 03/01–03/03: Examples polish and tests
+
+## Risks & Mitigations
+- Scope creep in examples → Define acceptance checklist per example
+- Process friction → Keep governance lightweight, automate checks in CI
+- Ownership gaps → Assign defaults in CODEOWNERS, revisit monthly
+
+## Acceptance Criteria for this PR
+- shared/DEVELOPMENT_PLAN.md present with Phase 1 backlog and dates
+- shared/ASSIGNMENTS.md present with roles/owners
+- .github/CODEOWNERS reflects core module ownership
+- .github/PULL_REQUEST_TEMPLATE.md includes governance checklist


### PR DESCRIPTION
## Summary
Create Phase 1 development plan and assignments; update governance templates.

### Changes
- Add shared/DEVELOPMENT_PLAN.md (Phase 1 backlog, schedule)
- Add shared/ASSIGNMENTS.md (roles, module ownership)
- Update .github/CODEOWNERS
- Update .github/PULL_REQUEST_TEMPLATE.md

### Acceptance Criteria
- shared docs present and linked
- CODEOWNERS and PR template updated

### Test Plan
- Docs build passes locally (N/A here)
- CI green
