### PR TITLE
ci: Node 20/22 matrix + pnpm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,12 @@ concurrency:
 
 jobs:
   ci:
-    name: Build, Lint & Test
+    name: Build, Lint & Test (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+      fail-fast: false
     timeout-minutes: 20
 
     steps:
@@ -28,10 +32,10 @@ jobs:
         with:
           version: 9
 
-      - name: Set up Node.js 20
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node }}
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Convert CI to a matrix across Node 20 and 22
- Keep pnpm cache enabled for faster runs
- Preserve concurrency and cancel-in-progress for quick feedback

## Why
- Validate compatibility across LTS (20) and current (22)
- Prevent regressions tied to a single runtime
- Keep PR feedback fast to meet ≤10 min target

## Notes
- Job timeout remains 20 minutes, typical run expected under 10
- Lint is non-blocking; typecheck and tests fail the job

## Checklist
- [x] Node matrix implemented
- [x] pnpm cache retained
- [x] Coverage artifact upload preserved

🤖 Generated with Claude Code