### PR TITLE
chore(lint): introduce ESLint v9 flat config and Prettier across repo

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,15 @@
+# Build artifacts
+**/dist/
+**/build/
+coverage/
+website/build/
+
+# Dependencies
+**/node_modules/
+
+# Generated files
+**/*.min.*
+**/generated/
+
+# Package manager files
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "semi": false,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,102 @@
+// ESLint Flat config for the whole monorepo
+// - TypeScript-first, Node 20+
+// - Integrates Prettier via eslint-config-prettier
+// - Keeps rules lightweight to avoid false positives across packages
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import globals from "globals";
+import importPlugin from "eslint-plugin-import";
+import unusedImports from "eslint-plugin-unused-imports";
+import configPrettier from "eslint-config-prettier";
+
+/** @type {import("eslint").Linter.FlatConfig[]} */
+export default [
+  // Global ignores (apply to all files)
+  {
+    ignores: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/build/**",
+      "coverage/**",
+      "website/build/**",
+      "**/.next/**",
+      "**/.turbo/**",
+      "**/out/**",
+      "**/*.min.*",
+      "**/generated/**",
+      "pnpm-lock.yaml",
+      "CHANGELOG.md",
+    ],
+  },
+
+  // Base language options
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        ...globals.node,
+        ...globals.es2022,
+      },
+    },
+  },
+
+  // JS recommended
+  js.configs.recommended,
+
+  // TS recommended (no type-checking by default to keep it fast and config-free)
+  ...tseslint.configs.recommended,
+
+  // Common rules and plugins
+  {
+    plugins: {
+      import: importPlugin,
+      "unused-imports": unusedImports,
+    },
+    rules: {
+      // General hygiene
+      "no-console": "off",
+      "no-debugger": "error",
+
+      // Import ordering
+      "import/order": [
+        "warn",
+        {
+          "newlines-between": "always",
+          alphabetize: { order: "asc", caseInsensitive: true },
+          groups: [["builtin", "external"], "internal", ["parent", "sibling", "index"], "object", "type"],
+        },
+      ],
+
+      // Unused imports/vars
+      "unused-imports/no-unused-imports": "warn",
+      "unused-imports/no-unused-vars": [
+        "warn",
+        {
+          vars: "all",
+          varsIgnorePattern: "^_",
+          args: "after-used",
+          argsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
+    },
+  },
+
+  // Test files (Jest globals)
+  {
+    files: ["**/*.test.{ts,tsx,js,jsx}", "**/*.spec.{ts,tsx,js,jsx}", "tests/**/*.{ts,tsx,js,jsx}"],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+      },
+    },
+    rules: {
+      "no-undef": "off",
+    },
+  },
+
+  // Let Prettier handle formatting concerns
+  configPrettier,
+];

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   ],
   "scripts": {
     "build": "pnpm -r build",
-    "lint": "pnpm -r lint",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier . --write",
+    "format:check": "prettier . --check",
     "typecheck": "pnpm -r typecheck",
     "dev": "pnpm --filter @xskynet/cli dev",
     "test": "jest",
@@ -26,7 +29,15 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "eslint": "^9.0.0",
+    "@eslint/js": "^9.0.0",
+    "typescript-eslint": "^7.0.0",
+    "globals": "^15.0.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-unused-imports": "^3.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "prettier": "^3.2.5"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary
- Add ESLint v9 Flat config at repo root (eslint.config.mjs)
- Add Prettier config (.prettierrc) and ignores (.prettierignore)
- Update root scripts: lint, lint:fix, format, format:check
- Keep rules lightweight; TS recommended without type-aware linting for speed

## Context
This is PR2 of Phase 1: lint/prettier + CI gate. It standardizes linting/formatting across the monorepo and prepares for CI enforcement in a follow-up PR.

## Notes
- No code changes besides config/scripts
- CI will be wired in PR3

## Test Plan
- pnpm i
- pnpm lint (should run using flat config)
- pnpm format:check (no-op initially)

🤖 Generated with Claude Code
