### PR TITLE
ci: fail CI on lint errors (PR4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: Lint
         run: pnpm run lint
-        continue-on-error: true
 
       - name: Run tests with coverage
         run: pnpm run test:coverage


### PR DESCRIPTION
## Summary
- Remove continue-on-error from Lint step in CI so lint failures fail the workflow.
- Aligns with Phase 1 PR4 requirement: fail-fast on lint to enforce quality gates.

## Test plan
- CI should now fail if `pnpm run lint` exits non-zero on PRs and pushes.
- Verified only change is removing the continue-on-error flag from lint step.

🤖 Generated by Mute (X‑Skynet)