### PR TITLE
ci: add Windows matrix; e2e hello; guarded PR auto-merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,11 @@
 <!-- Please describe the changes in this PR -->
 
 ## Testing
-<!-- Please describe how this was tested -->
+<!-- How was this tested? Include links to CI runs. -->
+
+- CI matrix: ubuntu + windows
+- Artifacts: ci-logs-* and hello-* artifacts uploaded on all legs (even failures)
+- Auto-merge: guarded by conditions and only when all required checks pass
 
 ## Documentation
 <!-- Please describe any documentation updates -->
@@ -19,3 +23,4 @@
 - [ ] Self-review completed
 - [ ] Tests added/updated (if applicable)
 - [ ] No new warnings introduced
+- [ ] Verified artifacts are present for failed matrix leg

--- a/.github/workflows/ci-e2e-hello.yml
+++ b/.github/workflows/ci-e2e-hello.yml
@@ -1,0 +1,48 @@
+name: CI E2E Hello
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "Name to say hello to"
+        required: false
+        default: "World"
+      force_fail:
+        description: "Force failure (1/0)"
+        required: false
+        default: "0"
+  pull_request:
+    paths:
+      - '.github/workflows/ci-e2e-hello.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-hello-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  hello:
+    name: Hello (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Say hello
+        run: |
+          echo "Hello, ${{ inputs.name || 'World' }} from ${{ matrix.os }}" | tee hello.txt
+      - name: Force failure (optional)
+        if: inputs.force_fail == '1' && matrix.os == 'windows-latest'
+        run: |
+          echo "Intentionally failing Windows leg" && exit 1
+      - name: Upload hello artifact (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hello-${{ matrix.os }}
+          path: hello.txt
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force_fail_one_leg:
+        description: "Force failure in Windows job (1/0)"
+        required: false
+        default: "0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,18 +21,28 @@ concurrency:
 
 jobs:
   ci:
-    name: Build, Lint & Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
+    name: Build, Lint & Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
+    env:
+      # Allow forcing a failure on the Windows leg for validation via repo variable or workflow_dispatch
+      FORCE_FAIL_ONE_LEG: ${{ inputs.force_fail_one_leg || vars.FORCE_FAIL_ONE_LEG || '0' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
+          run_install: false
 
       - name: Set up Node.js 20
         uses: actions/setup-node@v4
@@ -34,37 +50,56 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Prepare artifacts dir
+        run: mkdir -p artifacts
+
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile 2>&1 | tee artifacts/install-${{ matrix.os }}.log
 
       - name: Build
-        run: pnpm run build
+        run: pnpm run build 2>&1 | tee artifacts/build-${{ matrix.os }}.log
 
       - name: Typecheck
-        run: pnpm run typecheck
+        run: pnpm run typecheck 2>&1 | tee artifacts/typecheck-${{ matrix.os }}.log
         continue-on-error: false
 
       - name: Lint
-        run: pnpm run lint
+        run: pnpm run lint 2>&1 | tee artifacts/lint-${{ matrix.os }}.log
         continue-on-error: true
 
       - name: Run tests with coverage
-        run: pnpm run test:coverage
+        run: pnpm run test:coverage 2>&1 | tee artifacts/test-${{ matrix.os }}.log
         env:
           CI: true
 
-      - name: Upload coverage report
+      - name: Upload coverage report (ubuntu only)
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && matrix.os == 'ubuntu-latest'
         with:
           name: coverage-report
           path: coverage/
           retention-days: 7
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage to Codecov (push on ubuntu only)
         uses: codecov/codecov-action@v4
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
         with:
           files: coverage/lcov.info
           fail_ci_if_error: false
           verbose: false
+
+      - name: Optional forced failure on Windows
+        if: matrix.os == 'windows-latest' && (env.FORCE_FAIL_ONE_LEG == '1' || contains(github.ref_name, 'failwin'))
+        run: |
+          echo "Forcing failure on Windows leg as requested"
+          exit 1
+
+      - name: Upload logs (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-logs-${{ matrix.os }}
+          path: artifacts/*

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -1,0 +1,24 @@
+name: PR Auto Merge
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'automerge') &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge when checks pass
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          merge-method: squash
+          # Only enable after required checks succeed; action will fail if checks failing
+          # so we set 'fail-fast' behavior via default action semantics


### PR DESCRIPTION
This PR:

- Expands CI to ubuntu+windows matrix
- Ensures artifacts (logs, hello.txt) upload with if: always() even on failures
- Adds a dedicated 'CI E2E Hello' workflow to validate artifact handling and matrix failure behavior
- Introduces a guarded PR auto-merge workflow enabled by 'automerge' label on PRs into main, only after required checks pass

Testing notes:
- Trigger Windows-only forced failure by dispatching CI with input force_fail_one_leg=1 or adding 'failwin' in branch name
- CI E2E Hello can be dispatched with force_fail=1 to verify artifacts exist for both legs
- Ensure auto-merge only enables when label is present and checks are green.